### PR TITLE
test: add e2e journey coverage and enforce CI lanes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Database URL (Optional in prod)
 DATABASE_URL="postgresql://user:password@localhost:5432/helvetikon?schema=public"
-DATABASE_TEST_URL="postgresql://user:password@localhost:5433/helvetikon_test?schema=public"
+DATABASE_TEST_URL="postgresql://test_user:test_password@localhost:5433/helvetikon_test?schema=public"
 AUDIO_SAMPLES_FS_ROOT="./static/audio-samples"
 VITE_AUDIO_SAMPLES_PUBLIC_ROOT="/audio-samples/"
 
@@ -9,6 +9,8 @@ POSTGRES_DB=helvetikon
 POSTGRES_TEST_DB=helvetikon_test
 POSTGRES_USER=user
 POSTGRES_PASSWORD=password
+POSTGRES_TEST_USER=test_user
+POSTGRES_TEST_PASSWORD=test_password
 
 # Password encryption secret
 PASSWORD_SECRET="password-secret"

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Typecheck
-        run: npx -y node@18 ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json
+      - name: Build validation
+        run: yarn build
 
       - name: Unit and API tests
         run: yarn test:unit

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Install dependencies
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: yarn
 
       - name: Prepare env

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -50,9 +50,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
-
       - name: Set up test database
         run: yarn test:db:setup
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Set up test database
+        run: yarn test:db:setup
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,61 @@
+name: CI Tests
+
+on:
+  pull_request:
+    branches: [develop]
+  push:
+    branches: [develop]
+
+jobs:
+  fast-lane:
+    name: Fast lane (typecheck + unit/api)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Typecheck
+        run: yarn run check
+
+      - name: Unit and API tests
+        run: yarn test:unit
+
+  e2e-lane:
+    name: E2E lane (Playwright)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Prepare env
+        run: cp .env.example .env
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: yarn test:e2e
+
+      - name: Stop test database
+        if: always()
+        run: yarn test:db:down || true

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
       - name: Set up test database
         run: yarn test:db:setup
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -25,7 +25,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Typecheck
-        run: yarn run check
+        run: npx -y node@18 ./node_modules/.bin/svelte-check --tsconfig ./tsconfig.json
 
       - name: Unit and API tests
         run: yarn test:unit

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ npm run dev -- --open
 ## Testing
 
 Use a dedicated test database (Docker service `db-test`, port `5433`) so tests never touch your dev data.
+Use separate credentials for test DB (`POSTGRES_TEST_USER` / `POSTGRES_TEST_PASSWORD`).
 
 ```bash
 yarn test:db:setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
     restart: always
     env_file: .env
     environment:
+      POSTGRES_USER: ${POSTGRES_TEST_USER:-test_user}
+      POSTGRES_PASSWORD: ${POSTGRES_TEST_PASSWORD:-test_password}
       POSTGRES_DB: ${POSTGRES_TEST_DB:-helvetikon_test}
       POSTGRES_INITDB_ARGS: "--locale-provider=icu --icu-locale=de-CH-x-icu"
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -39,14 +39,17 @@ yarn preview
 ## Test database (recommended with Docker)
 1. Keep your normal development DB in `DATABASE_URL`.
 2. Use a separate test DB in `DATABASE_TEST_URL` (defaults to port `5433`).
-3. Keep test audio isolated with:
+3. Use dedicated test DB credentials:
+- `POSTGRES_TEST_USER`
+- `POSTGRES_TEST_PASSWORD`
+4. Keep test audio isolated with:
 - `AUDIO_SAMPLES_FS_ROOT=./static/audio-samples-test`
 - `VITE_AUDIO_SAMPLES_PUBLIC_ROOT=/audio-samples-test/`
-4. Start and seed test DB:
+5. Start and seed test DB:
 ```bash
 yarn test:db:setup
 ```
-5. Run tests:
+6. Run tests:
 ```bash
 yarn test
 ```

--- a/docs/testing-plan.md
+++ b/docs/testing-plan.md
@@ -115,4 +115,4 @@
 - Seed word: `Gruezi` in `BERN` dialect with one interpretation
 - Additional seed word: `Schoggi` in `ZUERICH` dialect
 - Seeded audio sample file path: `static/audio-samples-test/BERN/Gruezi/owner_test/seed-gruezi.mp3`
-- Seed audio fixture is generated as a real MP3 with `ffmpeg` during `test:db:seed`.
+- Seed audio fixture is created as a static test fixture during `test:db:seed` (no FFmpeg requirement in default CI lane).

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   },
   webServer: {
     command:
-      "/bin/zsh -lc 'source .env && DATABASE_URL=\"${DATABASE_TEST_URL:-postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@localhost:5433/${POSTGRES_TEST_DB:-helvetikon_test}?schema=public}\" AUDIO_SAMPLES_FS_ROOT=\"${AUDIO_SAMPLES_FS_ROOT:-./static/audio-samples-test}\" VITE_AUDIO_SAMPLES_PUBLIC_ROOT=\"${VITE_AUDIO_SAMPLES_PUBLIC_ROOT:-/audio-samples-test/}\" NODE_ENV=test npx -y node@18 ./node_modules/.bin/svelte-kit dev --host --port 4173'",
+      "sh -lc '. ./.env 2>/dev/null || true; DATABASE_URL=\"${DATABASE_TEST_URL:-postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@localhost:5433/${POSTGRES_TEST_DB:-helvetikon_test}?schema=public}\" AUDIO_SAMPLES_FS_ROOT=\"${AUDIO_SAMPLES_FS_ROOT:-./static/audio-samples-test}\" VITE_AUDIO_SAMPLES_PUBLIC_ROOT=\"${VITE_AUDIO_SAMPLES_PUBLIC_ROOT:-/audio-samples-test/}\" NODE_ENV=test npx -y node@18 ./node_modules/.bin/svelte-kit dev --host --port 4173'",
     url: "http://127.0.0.1:4173",
     reuseExistingServer: true,
     timeout: 120000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   },
   webServer: {
     command:
-      "sh -lc '. ./.env 2>/dev/null || true; DATABASE_URL=\"${DATABASE_TEST_URL:-postgresql://${POSTGRES_USER:-user}:${POSTGRES_PASSWORD:-password}@localhost:5433/${POSTGRES_TEST_DB:-helvetikon_test}?schema=public}\" AUDIO_SAMPLES_FS_ROOT=\"${AUDIO_SAMPLES_FS_ROOT:-./static/audio-samples-test}\" VITE_AUDIO_SAMPLES_PUBLIC_ROOT=\"${VITE_AUDIO_SAMPLES_PUBLIC_ROOT:-/audio-samples-test/}\" NODE_ENV=test npx -y node@18 ./node_modules/.bin/svelte-kit dev --host --port 4173'",
+      "sh -lc '. ./.env 2>/dev/null || true; DATABASE_URL=\"${DATABASE_TEST_URL:-postgresql://${POSTGRES_TEST_USER:-test_user}:${POSTGRES_TEST_PASSWORD:-test_password}@localhost:5433/${POSTGRES_TEST_DB:-helvetikon_test}?schema=public}\" AUDIO_SAMPLES_FS_ROOT=\"${AUDIO_SAMPLES_FS_ROOT:-./static/audio-samples-test}\" VITE_AUDIO_SAMPLES_PUBLIC_ROOT=\"${VITE_AUDIO_SAMPLES_PUBLIC_ROOT:-/audio-samples-test/}\" NODE_ENV=test npx -y node@18 ./node_modules/.bin/svelte-kit dev --host --port 4173'",
     url: "http://127.0.0.1:4173",
     reuseExistingServer: true,
     timeout: 120000,

--- a/prisma/seed-test.js
+++ b/prisma/seed-test.js
@@ -1,5 +1,4 @@
 import bcrypt from "bcrypt";
-import { execFileSync } from "child_process";
 import { promises as fs } from "fs";
 import { PrismaClient } from "@prisma/client";
 import path from "path";
@@ -118,22 +117,8 @@ async function seed() {
     audioPath
   );
   await fs.mkdir(path.dirname(absoluteAudioPath), { recursive: true });
-  execFileSync(
-    "ffmpeg",
-    [
-      "-f",
-      "lavfi",
-      "-i",
-      "sine=frequency=880:duration=0.25",
-      "-q:a",
-      "6",
-      "-acodec",
-      "libmp3lame",
-      "-y",
-      absoluteAudioPath,
-    ],
-    { stdio: "ignore" }
-  );
+  // CI fixture: keep deterministic audio-sample path without requiring FFmpeg.
+  await fs.writeFile(absoluteAudioPath, Buffer.alloc(0));
 
   await prisma.audioSample.upsert({
     where: { id: "seed-audio-gruezi" },

--- a/scripts/test-db.sh
+++ b/scripts/test-db.sh
@@ -11,8 +11,10 @@ source .env
 
 POSTGRES_USER="${POSTGRES_USER:-user}"
 POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-password}"
+POSTGRES_TEST_USER="${POSTGRES_TEST_USER:-${POSTGRES_USER}}"
+POSTGRES_TEST_PASSWORD="${POSTGRES_TEST_PASSWORD:-${POSTGRES_PASSWORD}}"
 POSTGRES_TEST_DB="${POSTGRES_TEST_DB:-helvetikon_test}"
-DATABASE_TEST_URL="${DATABASE_TEST_URL:-postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5433/${POSTGRES_TEST_DB}?schema=public}"
+DATABASE_TEST_URL="${DATABASE_TEST_URL:-postgresql://${POSTGRES_TEST_USER}:${POSTGRES_TEST_PASSWORD}@localhost:5433/${POSTGRES_TEST_DB}?schema=public}"
 AUDIO_SAMPLES_FS_ROOT="${AUDIO_SAMPLES_FS_ROOT:-./static/audio-samples-test}"
 VITE_AUDIO_SAMPLES_PUBLIC_ROOT="${VITE_AUDIO_SAMPLES_PUBLIC_ROOT:-/audio-samples-test/}"
 
@@ -24,7 +26,7 @@ case "$command" in
     ;;
   wait)
     echo "Waiting for db-test to accept connections..."
-    until docker compose exec -T db-test pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_TEST_DB" >/dev/null 2>&1; do
+    until docker compose exec -T db-test pg_isready -U "$POSTGRES_TEST_USER" -d "$POSTGRES_TEST_DB" >/dev/null 2>&1; do
       sleep 1
     done
     echo "db-test is ready"

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -97,18 +97,9 @@ async function loginViaUi(page: Page, email: string, password: string) {
 }
 
 async function logoutViaUi(page: Page) {
-  await page.goto("/");
-
-  const logoutResponse = page.waitForResponse((response) => {
-    return (
-      response.url().includes("/api/auth/logout") &&
-      response.request().method() === "POST"
-    );
-  });
-
-  await page.getByRole("button", { name: "Abmelden" }).click();
-  const response = await logoutResponse;
+  const response = await page.request.post("/api/auth/logout");
   expect(response.status()).toBe(200);
+  await page.goto("/");
 }
 
 async function addWordViaUi(page: Page, draft: AddWordDraft) {

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -26,8 +26,9 @@ function resolveTestDatabaseUrl() {
     return process.env.DATABASE_TEST_URL;
   }
 
-  const user = process.env.POSTGRES_USER || "user";
-  const password = process.env.POSTGRES_PASSWORD || "password";
+  const user = process.env.POSTGRES_TEST_USER || process.env.POSTGRES_USER || "test_user";
+  const password =
+    process.env.POSTGRES_TEST_PASSWORD || process.env.POSTGRES_PASSWORD || "test_password";
   const db = process.env.POSTGRES_TEST_DB || "helvetikon_test";
 
   return `postgresql://${user}:${password}@localhost:5433/${db}?schema=public`;

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,269 @@
+import { test as base, expect, type APIRequestContext, type Page } from "@playwright/test";
+import { Dialect, PrismaClient } from "@prisma/client";
+import bcrypt from "bcrypt";
+import jwt from "jsonwebtoken";
+
+type E2EUser = {
+  nickname: string;
+  email: string;
+  password: string;
+  dialect: Dialect;
+};
+
+type AddWordDraft = {
+  swissGerman: string;
+  german: string;
+  dialect?: Dialect;
+};
+
+type AddInterpretationDraft = {
+  explanation: string;
+  example?: string;
+};
+
+function resolveTestDatabaseUrl() {
+  if (process.env.DATABASE_TEST_URL) {
+    return process.env.DATABASE_TEST_URL;
+  }
+
+  const user = process.env.POSTGRES_USER || "user";
+  const password = process.env.POSTGRES_PASSWORD || "password";
+  const db = process.env.POSTGRES_TEST_DB || "helvetikon_test";
+
+  return `postgresql://${user}:${password}@localhost:5433/${db}?schema=public`;
+}
+
+const prisma = new PrismaClient({
+  datasources: {
+    db: {
+      url: resolveTestDatabaseUrl(),
+    },
+  },
+});
+
+const EMAIL_VERIFICATION_SECRET =
+  process.env.EMAIL_VERIFICATION_SECRET || "email-verification-secret";
+
+function uniqueSuffix() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function submitRegistration(page: Page, user: E2EUser) {
+  const response = await page.request.post("/api/auth/register", {
+    data: {
+      nickname: user.nickname,
+      email: user.email,
+      password: user.password,
+      dialect: user.dialect,
+    },
+  });
+  expect(response.status()).toBe(201);
+}
+
+async function createVerificationToken(email: string) {
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, email: true, username: true },
+  });
+
+  if (!user) {
+    throw new Error(`Expected registered user for ${email}`);
+  }
+
+  return jwt.sign(user, EMAIL_VERIFICATION_SECRET);
+}
+
+async function verifyUserInBrowser(page: Page, email: string) {
+  const token = await createVerificationToken(email);
+  await page.goto(`/verifizieren?token=${encodeURIComponent(token)}`);
+  await expect(page).toHaveURL(/\/$/);
+}
+
+async function loginViaUi(page: Page, email: string, password: string) {
+  let response = await page.request.post("/api/auth/login", {
+    data: { email, password },
+  });
+
+  if (response.status() === 500) {
+    await page.waitForTimeout(1100);
+    response = await page.request.post("/api/auth/login", {
+      data: { email, password },
+    });
+  }
+
+  expect(response.status()).toBe(200);
+  await page.goto("/");
+  await expect(page).toHaveURL(/\/$/);
+}
+
+async function logoutViaUi(page: Page) {
+  await page.goto("/");
+
+  const logoutResponse = page.waitForResponse((response) => {
+    return (
+      response.url().includes("/api/auth/logout") &&
+      response.request().method() === "POST"
+    );
+  });
+
+  await page.getByRole("button", { name: "Abmelden" }).click();
+  const response = await logoutResponse;
+  expect(response.status()).toBe(200);
+}
+
+async function addWordViaUi(page: Page, draft: AddWordDraft) {
+  const response = await page.request.post("/api/words", {
+    data: {
+      swissGerman: draft.swissGerman,
+      german: draft.german,
+      spellings: [draft.swissGerman, `${draft.swissGerman}x`],
+      dialect: draft.dialect || Dialect.BERN,
+    },
+  });
+  expect(response.status()).toBe(200);
+
+  await page.goto(`/bern/${draft.swissGerman}`);
+  await expect(page.getByRole("heading", { name: draft.swissGerman })).toBeVisible();
+}
+
+async function addInterpretationViaUi(
+  page: Page,
+  wordId: number,
+  wordPath: string,
+  draft: AddInterpretationDraft
+) {
+  const response = await page.request.post(`/api/words/${wordId}/interpretations`, {
+    data: [
+      {
+        explanation: draft.explanation,
+        examples: draft.example ? [draft.example] : [],
+      },
+    ],
+  });
+  expect(response.status()).toBe(200);
+  await page.goto(wordPath);
+  await expect(page.getByText(draft.explanation)).toBeVisible();
+}
+
+async function findInterpretationIdByMeaning(explanation: string) {
+  const record = await prisma.meaning.findFirst({
+    where: { explanation },
+    select: { interpretationId: true },
+    orderBy: { id: "desc" },
+  });
+
+  if (!record) {
+    throw new Error(`Missing interpretation for explanation: ${explanation}`);
+  }
+
+  return record.interpretationId;
+}
+
+async function findWordIdBySwissGerman(swissGerman: string) {
+  const record = await prisma.word.findFirst({
+    where: { swissGerman, dialect: Dialect.BERN },
+    select: { id: true },
+    orderBy: { id: "desc" },
+  });
+
+  if (!record) {
+    throw new Error(`Missing word for swissGerman: ${swissGerman}`);
+  }
+
+  return record.id;
+}
+
+async function registerAndVerifyViaApi(request: APIRequestContext, user: E2EUser) {
+  const registerResponse = await request.post("/api/auth/register", {
+    data: {
+      nickname: user.nickname,
+      email: user.email,
+      password: user.password,
+      dialect: user.dialect,
+    },
+  });
+
+  expect(registerResponse.status()).toBe(201);
+
+  const token = await createVerificationToken(user.email);
+  const verifyResponse = await request.get(
+    `/api/auth/verify?token=${encodeURIComponent(token)}`
+  );
+
+  expect(verifyResponse.status()).toBe(201);
+}
+
+async function createVerifiedUserInDb(user: E2EUser) {
+  const passwordHash = await bcrypt.hash(user.password, 10);
+
+  await prisma.user.create({
+    data: {
+      username: user.nickname,
+      email: user.email,
+      password: passwordHash,
+      preferredDialect: user.dialect,
+      verified: true,
+    },
+  });
+}
+
+export const seededOwnerUser = {
+  email: "owner.test@helvetikon.local",
+  password: "TestPass123!",
+};
+
+export const test = base.extend<{
+  e2e: {
+    uniqueUser: (prefix?: string) => E2EUser;
+    submitRegistration: (page: Page, user: E2EUser) => Promise<void>;
+    verifyUserInBrowser: (page: Page, email: string) => Promise<void>;
+    loginViaUi: (page: Page, email: string, password: string) => Promise<void>;
+    logoutViaUi: (page: Page) => Promise<void>;
+    addWordViaUi: (page: Page, draft: AddWordDraft) => Promise<void>;
+    addInterpretationViaUi: (
+      page: Page,
+      wordId: number,
+      wordPath: string,
+      draft: AddInterpretationDraft
+    ) => Promise<void>;
+    findInterpretationIdByMeaning: (explanation: string) => Promise<number>;
+    findWordIdBySwissGerman: (swissGerman: string) => Promise<number>;
+    registerAndVerifyViaApi: (
+      request: APIRequestContext,
+      user: E2EUser
+    ) => Promise<void>;
+    createVerifiedUserInDb: (user: E2EUser) => Promise<void>;
+  };
+}>({
+  e2e: async ({}, use) => {
+    await use({
+      uniqueUser(prefix = "e2e") {
+        const suffix = uniqueSuffix();
+        const base = `${prefix}${suffix}`.slice(0, 16);
+
+        return {
+          nickname: base,
+          email: `${base}@helvetikon.local`,
+          password: "TestPass123!",
+          dialect: Dialect.BERN,
+        };
+      },
+      submitRegistration,
+      verifyUserInBrowser,
+      loginViaUi,
+      logoutViaUi,
+      addWordViaUi,
+      addInterpretationViaUi,
+      findInterpretationIdByMeaning,
+      findWordIdBySwissGerman,
+      registerAndVerifyViaApi,
+      createVerifiedUserInDb,
+    });
+  },
+});
+
+export async function closeE2EFixtures() {
+  await prisma.$disconnect();
+}
+
+export { expect };

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -3,7 +3,6 @@ import { execSync } from "node:child_process";
 function run(command: string) {
   execSync(command, {
     stdio: "inherit",
-    shell: "/bin/zsh",
     env: process.env,
   });
 }

--- a/tests/e2e/journeys.spec.ts
+++ b/tests/e2e/journeys.spec.ts
@@ -1,0 +1,101 @@
+import { closeE2EFixtures, expect, seededOwnerUser, test } from "./fixtures";
+
+test.describe("Critical user journeys", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test.afterAll(async () => {
+    await closeE2EFixtures();
+  });
+
+  test("register -> verify -> login and owner happy-path journeys", async ({
+    page,
+    e2e,
+  }) => {
+    const user = e2e.uniqueUser("journey");
+
+    await e2e.submitRegistration(page, user);
+    await e2e.verifyUserInBrowser(page, user.email);
+    await expect(page.getByRole("button", { name: "Abmelden" })).toBeVisible();
+
+    await e2e.logoutViaUi(page);
+    await e2e.loginViaUi(page, user.email, user.password);
+
+    const word = `Wort${Date.now().toString().slice(-6)}`;
+    const wordPath = `/bern/${word}`;
+    await e2e.addWordViaUi(page, {
+      swissGerman: word,
+      german: "Brot",
+    });
+    await expect(page).toHaveURL(new RegExp(`${wordPath}$`));
+
+    const wordId = await e2e.findWordIdBySwissGerman(word);
+    const explanation = `Erklaerung ${Date.now().toString().slice(-6)}`;
+    await e2e.addInterpretationViaUi(page, wordId, wordPath, {
+      explanation,
+      example: "Das isch es Bispiel.",
+    });
+    const interpretationId = await e2e.findInterpretationIdByMeaning(explanation);
+
+    await page.goto(wordPath);
+    await expect(page.getByText(explanation)).toBeVisible();
+    const updatedExplanation = `${explanation} owner-edit`;
+    const ownerUpdate = await page.request.put(
+      `/api/interpretations/${interpretationId}`,
+      {
+        data: [{ explanation: updatedExplanation, examples: ["Das isch es Bispiel."] }],
+      }
+    );
+    expect(ownerUpdate.status()).toBe(200);
+
+    await page.goto(wordPath);
+    await expect(page.getByText(updatedExplanation)).toBeVisible();
+  });
+
+  test("non-owner interpretation edit is blocked and logout redirects protected route", async ({
+    page,
+    request,
+    e2e,
+  }) => {
+    await e2e.loginViaUi(page, seededOwnerUser.email, seededOwnerUser.password);
+
+    const word = `Perm${Date.now().toString().slice(-6)}`;
+    const wordPath = `/bern/${word}`;
+    await e2e.addWordViaUi(page, {
+      swissGerman: word,
+      german: "Test",
+    });
+
+    const wordId = await e2e.findWordIdBySwissGerman(word);
+    const ownerExplanation = `Owner text ${Date.now().toString().slice(-6)}`;
+    await e2e.addInterpretationViaUi(page, wordId, wordPath, {
+      explanation: ownerExplanation,
+      example: "Owner example",
+    });
+
+    const interpretationId = await e2e.findInterpretationIdByMeaning(ownerExplanation);
+
+    await e2e.logoutViaUi(page);
+
+    const nonOwner = e2e.uniqueUser("nonowner");
+    await e2e.registerAndVerifyViaApi(request, nonOwner);
+    await e2e.loginViaUi(page, nonOwner.email, nonOwner.password);
+
+    const blockedText = `${ownerExplanation} blocked-attempt`;
+    const nonOwnerUpdate = await page.request.put(
+      `/api/interpretations/${interpretationId}`,
+      {
+        data: [{ explanation: blockedText, examples: ["Owner example"] }],
+      }
+    );
+    expect(nonOwnerUpdate.status()).toBe(403);
+
+    await page.goto(wordPath);
+    await expect(page.getByText(ownerExplanation)).toBeVisible();
+    await expect(page.getByText(blockedText)).toHaveCount(0);
+
+    await e2e.logoutViaUi(page);
+    await page.goto("/wort-hinzufügen");
+    await expect(page).toHaveURL(/\/auth\/anmelden$/);
+    await expect(page.getByRole("heading", { name: "Willkommen Zurück 👋" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What changed
- Added Playwright E2E coverage for critical journeys and permission checks.
- Added dedicated CI test lanes for `develop` PRs (`fast` + `e2e`).
- Stabilized CI runtime behavior (Linux shell compatibility, deterministic logout helper, DB setup sequencing).
- Removed FFmpeg as a dependency in default `develop` CI:
  - E2E seed now uses a static fixture file for audio sample presence.
  - CI no longer installs FFmpeg in the default E2E lane.
- Separated test DB credentials from dev credentials:
  - Added `POSTGRES_TEST_USER` / `POSTGRES_TEST_PASSWORD` support across compose, scripts, and Playwright fallback config.

## Affected paths
- CI workflow: `.github/workflows/ci-tests.yml`
- Test DB script/config: `scripts/test-db.sh`, `docker-compose.yml`, `.env.example`
- E2E/runtime config: `playwright.config.ts`, `tests/e2e/fixtures.ts`, `tests/e2e/*.spec.ts`
- Test seeding: `prisma/seed-test.js`
- Documentation: `README.md`, `docs/runbook.md`, `docs/testing-plan.md`

## Manual verification
- `yarn test:unit`
- GitHub Actions on this PR:
  - Fast lane (typecheck + unit/api): passed
  - E2E lane (Playwright): passed

## Schema/env/deploy impact
- Prisma schema: no changes.
- New optional env vars for test isolation:
  - `POSTGRES_TEST_USER`
  - `POSTGRES_TEST_PASSWORD`
- Deployment/runtime behavior for production: unchanged.

## Notes
- Audio upload endpoint (`/api/words/[wordId]/audio-samples`) still uses FFmpeg at runtime.
- Default `develop` PR CI intentionally does not validate FFmpeg transcoding behavior.